### PR TITLE
package: add version field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "cluster-update",
   "description": "cockpit cluster update",
+  "version": "1.0.0",
   "type": "module",
   "main": "index.js",
   "repository": "",


### PR DESCRIPTION
Yocto's "devtool add" feature used to create a recipe requires a version number in the package.json to recognize that it's a project using npm and create the recipe based on this information.